### PR TITLE
[TASK] Streamline style of List template

### DIFF
--- a/Resources/Private/Templates/Consent/List.html
+++ b/Resources/Private/Templates/Consent/List.html
@@ -6,7 +6,7 @@
 				<span class="service__headline">{service.title}</span>
 				<f:format.html>{service.description}</f:format.html>
 
-				<table class="table table-striped table-hover table-sm">
+				<table class="table table-bordered table-striped">
 					<caption>Cookies</caption>
 					<thead>
 						<tr>
@@ -21,6 +21,6 @@
 				</table>
 			</f:if>
 		</f:for>
-		<a href="#" class="btn btn-primary btn-lg js-showConsentModal"><f:translate key="list.button.openConsent" /></a>
+		<a href="#" class="btn btn-primary js-showConsentModal"><f:translate key="list.button.openConsent" /></a>
 	</f:section>
 </html>


### PR DESCRIPTION
This small change removes some styles in the List template to integrate better into projects using Bootstrap without having the need to create an override.

With this being basically _a breaking change_ for some projects, I could also imagine a new TypoScript setting where the used classes can be configured. Looking forward for any feedback!