### PR TITLE
Add feature toggles for renderers

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,9 +3,15 @@ defined('TYPO3') || die('Access denied.');
 
 call_user_func(
     function () {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['we_cookie_consent.YoutubeRenderer'] ??= true;
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['we_cookie_consent.VimeoRenderer'] ??= true;
 		$rendererRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\Rendering\RendererRegistry::class);
-		$rendererRegistry->registerRendererClass(\Websedit\WeCookieConsent\Resource\Rendering\YouTubeRenderer::class);
-		$rendererRegistry->registerRendererClass(\Websedit\WeCookieConsent\Resource\Rendering\VimeoRenderer::class);
+        if($GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['we_cookie_consent.YoutubeRenderer']) {
+            $rendererRegistry->registerRendererClass(\Websedit\WeCookieConsent\Resource\Rendering\YouTubeRenderer::class);
+        }
+        if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['we_cookie_consent.VimeoRenderer']) {
+            $rendererRegistry->registerRendererClass(\Websedit\WeCookieConsent\Resource\Rendering\VimeoRenderer::class);
+        }
 
 	    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
 	         'WeCookieConsent',


### PR DESCRIPTION
This adds the Youtube and Vimeo renderer behind two feature toggles, which are active by default.
So it should be easy now to disable them if so desired.

This resolves #26 