### PR TITLE
Make it easier to override scss variables

### DIFF
--- a/Resources/Public/Stylesheet/Sass/_base.scss
+++ b/Resources/Public/Stylesheet/Sass/_base.scss
@@ -2,108 +2,108 @@
 // Variables:
 
 // Relative path to original EXT:we_cookie_consent - Ver 2.1.0  -gf20211124
-$path-to-wcc : "../../../../";  
-$path-to-ext : "../";
-$path-to-wcc-images : $path-to-wcc + "we_cookie_consent/Resources/Public/Images/";
-$path-to-wcc-icons : $path-to-wcc + "we_cookie_consent/Resources/Public/Icons/";
+$path-to-wcc : "../../../../" !default;
+$path-to-ext : "../" !default;
+$path-to-wcc-images : $path-to-wcc + "we_cookie_consent/Resources/Public/Images/" !default;
+$path-to-wcc-icons : $path-to-wcc + "we_cookie_consent/Resources/Public/Icons/" !default;
 // Relative path to current EXT
-$path-to-ext-images : $path-to-ext + "Images/";
-$path-to-ext-icons : $path-to-ext + "Icons/";
+$path-to-ext-images : $path-to-ext + "Images/" !default;
+$path-to-ext-icons : $path-to-ext + "Icons/" !default;
 
-$base-font-size:14px;
+$base-font-size:14px !default;
 
-$color-default : #161f57;
-$color-black : #000;
-$color-white : #FFF;
-$color-none : transparent;
-$color-grey : #EFEFEF;
-$color-white-90-percent : #FFFFFFE0;
+$color-default : #161f57 !default;
+$color-black : #000 !default;
+$color-white : #FFF !default;
+$color-none : transparent !default;
+$color-grey : #EFEFEF !default;
+$color-white-90-percent : #FFFFFFE0 !default;
 
-$opacity-hover : .7;  // Ver 2.1.0  -gf20211125
+$opacity-hover : .7 !default;  // Ver 2.1.0  -gf20211125
 
 // Icons Buttons
-$icon-edit: url( $path-to-ext-icons + "icon-pen.svg");
-$icon-accept: url( $path-to-ext-icons + "icon-check-dark.svg");
-$icon-success: url( $path-to-ext-icons + "icon-check-dark.svg");
-$icon-decline: url( $path-to-ext-icons + "icon-close.svg");
+$icon-edit: url( $path-to-ext-icons + "icon-pen.svg") !default;
+$icon-accept: url( $path-to-ext-icons + "icon-check-dark.svg") !default;
+$icon-success: url( $path-to-ext-icons + "icon-check-dark.svg") !default;
+$icon-decline: url( $path-to-ext-icons + "icon-close.svg") !default;
 // Icons Buttons bei Hover:
-$icon-hover-edit: url( $path-to-ext-icons + "icon-pen.svg");
-$icon-hover-accept: url( $path-to-ext-icons + "icon-check-dark.svg");
-$icon-hover-success: url( $path-to-ext-icons + "icon-check-dark.svg");
-$icon-hover-decline: url( $path-to-ext-icons + "icon-close.svg");
+$icon-hover-edit: url( $path-to-ext-icons + "icon-pen.svg") !default;
+$icon-hover-accept: url( $path-to-ext-icons + "icon-check-dark.svg") !default;
+$icon-hover-success: url( $path-to-ext-icons + "icon-check-dark.svg") !default;
+$icon-hover-decline: url( $path-to-ext-icons + "icon-close.svg") !default;
 
 // Icons Settings
-$icon-slider-yes: url( $path-to-ext-icons + "icon-yes.svg");
-$icon-slider-no: url( $path-to-ext-icons + "icon-no.svg");
-$icon-slider-locked: url( $path-to-ext-icons + "icon-locked.svg");
-$icon-settings-close: '\00d7';
-$icon-settings-close-size: 4em;
-$icon-settings-close-color: #FFF;
+$icon-slider-yes: url( $path-to-ext-icons + "icon-yes.svg") !default;
+$icon-slider-no: url( $path-to-ext-icons + "icon-no.svg") !default;
+$icon-slider-locked: url( $path-to-ext-icons + "icon-locked.svg") !default;
+$icon-settings-close: '\00d7' !default;
+$icon-settings-close-size: 4em !default;
+$icon-settings-close-color: #FFF !default;
 
 // Backgroud colors:
 // Background Popup:
-$color-bg: #FFF;
+$color-bg: #FFF !default;
 // Background colours Buttons
-$color-bg-edit: #FFF;
-$color-bg-accept: #FFF;
-$color-bg-accept-all: transparent;
-$color-bg-success: #FFF;
-$color-bg-decline: #FFF;
-$color-bg-link: transparent;
-$color-bg-primary: #F7A925;
+$color-bg-edit: #FFF !default;
+$color-bg-accept: #FFF !default;
+$color-bg-accept-all: transparent !default;
+$color-bg-success: #FFF !default;
+$color-bg-decline: #FFF !default;
+$color-bg-link: transparent !default;
+$color-bg-primary: #F7A925 !default;
 // Font colours buttons
-$color-font-edit: #00AFCB;
-$color-font-accept: #161f57;
-$color-font-success: #161f57;
-$color-font-decline: #161f57;
-$color-font-primary: #FFF;
+$color-font-edit: #00AFCB !default;
+$color-font-accept: #161f57 !default;
+$color-font-success: #161f57 !default;
+$color-font-decline: #161f57 !default;
+$color-font-primary: #FFF !default;
 
 // Border Colors
-$color-border: #00AFCB;
-$color-hover-border: #00AFCB;
+$color-border: #00AFCB !default;
+$color-hover-border: #00AFCB !default;
 
 // Border properties:
-$border-width: 2px;
-$border-radius: 4px;
-$border-style: $border-width solid $color-border;
-$border-hover-style: $border-width solid rgba(0,0,0,.1);
+$border-width: 2px !default;
+$border-radius: 4px !default;
+$border-style: $border-width solid $color-border !default;
+$border-hover-style: $border-width solid rgba(0,0,0,.1) !default;
 
 // Sliders and Locker icon
-$color-slider:#EFEFEF;
-$color-slider-half-active:#DADADA;
-$color-slider-active:#C9C9C9;
-$color-slider-knop:#B1D6E8; // rgb(177,214,232)
-$color-slider-knop-half-active: #63ADD1; // rgb(99,173,209)
-$color-slider-knop-active: #008000; // rgb(0,128,0);  [#63ADD1; // rgb(99,173,209)]
+$color-slider:#EFEFEF !default;
+$color-slider-half-active:#DADADA !default;
+$color-slider-active:#C9C9C9 !default;
+$color-slider-knop:#B1D6E8 !default; // rgb(177,214,232)
+$color-slider-knop-half-active: #63ADD1 !default; // rgb(99,173,209)
+$color-slider-knop-active: #008000 !default; // rgb(0,128,0) !default;  [#63ADD1 !default; // rgb(99,173,209)]
 
 
 // Assignment colours/properties to buttons:
-$cm-btn-color: $color-default;
-$cm-btn-color-bg: $color-grey;
-$cm-btn-color-border: $color-border;
-$cm-btn-border: $border-style;
+$cm-btn-color: $color-default !default;
+$cm-btn-color-bg: $color-grey !default;
+$cm-btn-color-border: $color-border !default;
+$cm-btn-border: $border-style !default;
 
-$cm-link-bg : $color-bg-link;
-$cm-link-border : none;
+$cm-link-bg : $color-bg-link !default;
+$cm-link-border : none !default;
 
-$cm-btn-color-success: $color-font-success;
-$cm-btn-color-bg-success: $color-bg-success;
-$cm-btn-color-bg-decline: $color-bg-decline;
-$cm-btn-color-bg-primary: $color-bg-primary;
+$cm-btn-color-success: $color-font-success !default;
+$cm-btn-color-bg-success: $color-bg-success !default;
+$cm-btn-color-bg-decline: $color-bg-decline !default;
+$cm-btn-color-bg-primary: $color-bg-primary !default;
 
-$border-top-purpose: $border-hover-style;
+$border-top-purpose: $border-hover-style !default;
 
-$video-overlay-bg : $color-white-90-percent;
+$video-overlay-bg : $color-white-90-percent !default;
 
 // Table colours (privacy page)
-$table-headline-color : $color-default;
-$table-bg-color : $color-none;
-$table-row-bg-color : $color-slider;
-$table-border-color : #ABABAB;
+$table-headline-color : $color-default !default;
+$table-bg-color : $color-none !default;
+$table-row-bg-color : $color-slider !default;
+$table-border-color : #ABABAB !default;
 
 // Paddings und Margins
-$spacing-top-bottom : 20px;
-$spacing-left-right : 30px;
+$spacing-top-bottom : 20px !default;
+$spacing-left-right : 30px !default;
 
 /*
 
@@ -151,10 +151,10 @@ To do:
 .klaro.we_cookie_consent .cookie-modal {
 	h1,
 	h2,
-	li, 
+	li,
 	p,
-	a, 
-	strong, 
+	a,
+	strong,
 	ul {
 		color: $color-default;
 		font-size: 1em;

--- a/Resources/Public/Stylesheet/Sass/_cookie-modal.scss
+++ b/Resources/Public/Stylesheet/Sass/_cookie-modal.scss
@@ -22,7 +22,7 @@
 				&.cm-services,
 				&.cm-purposes {
 					li {
-						&.cm-service, 
+						&.cm-service,
 						&.cm-purpose {
 							padding-left: 72px;
 						}
@@ -34,21 +34,21 @@
 						}
 					}
 				}
-				&.cm-services li.cm-purpose .cm-services .cm-content, 
+				&.cm-services li.cm-purpose .cm-services .cm-content,
 				&.cm-purposes li.cm-purpose .cm-services .cm-content {
 					margin-left: -72px;
-				}		
+				}
 			}
 		}
 
-		// ACTIVATE grouping of services by category: 
+		// ACTIVATE grouping of services by category:
 		.cm-purpose {
 			padding-left: 92px;
 			border-top: $border-top-purpose;
 			padding-top: .5em;
 			> {
-				.cm-list-label .slider, 
-				.cm-list-input:checked + .cm-list-label .slider, 
+				.cm-list-label .slider,
+				.cm-list-input:checked + .cm-list-label .slider,
 				.cm-list-input.required:checked + .cm-list-label .slider{
 					background-color: $color-slider;
 					top: 2px;
@@ -101,7 +101,7 @@
 				.cm-list-input:not(.half-checked):checked + .cm-list-label > .cm-list-title + .cm-switch::before {
 					content: $icon-slider-yes;	// Slider-Symbol "no"
 				}
-				.cm-list-label .cm-required ~ .cm-cswitch .slider, 
+				.cm-list-label .cm-required ~ .cm-cswitch .slider,
 				.cm-list-input:checked + .cm-list-label .cm-required ~ .cm-switch .slider {
 					background: $icon-slider-locked no-repeat transparent; // Icon "active + not changable"
 					border-radius: unset;
@@ -118,13 +118,13 @@
 				}
 			}
 		}
-		
-	
-		// NO grouping of services by category - just listing: 
+
+
+		// NO grouping of services by category - just listing:
 		.cm-service > div > {
 		// .cm-service.cm-toggle-all > div > {
-			.cm-list-label .slider, 
-			.cm-list-input:checked + .cm-list-label .slider, 
+			.cm-list-label .slider,
+			.cm-list-input:checked + .cm-list-label .slider,
 			.cm-list-input.required:checked + .cm-list-label .slider{
 				background-color: $color-slider;
 				top: 2px;
@@ -133,7 +133,7 @@
 			.cm-list-label .cm-required {
 				margin-left:.5em;
 			}
-			
+
 			.cm-list-label .slider::before {
 				background-color: $color-slider-knop;
 				bottom: 2px;
@@ -181,7 +181,7 @@
 				padding: 2px;
 				width: 16px;
 			}
-			.cm-list-label .cm-required ~ .cm-cswitch .slider, 
+			.cm-list-label .cm-required ~ .cm-cswitch .slider,
 			.cm-list-input:checked + .cm-list-label .cm-required ~ .cm-switch .slider {
 				background: $icon-slider-locked no-repeat transparent;	// Icon "active + not changable"
 				border-radius: unset;
@@ -250,7 +250,7 @@
 					}
 				}
 			}
-			.cm-toggle-all { 
+			.cm-toggle-all {
 				.cm-purpose-description {
 					display: block;
 				}
@@ -270,11 +270,11 @@
 				width: 100%;
 				z-index:10;
 				> * {
-					align-content:flex-end;					
+					align-content:flex-end;
 					display: flex;
 					flex-wrap:wrap;
 					height:calc(100% - 2em);
-					justify-content:end;
+					justify-content:flex-end;
 					margin: 0;
 					width:100%;
 					max-width:100%;
@@ -380,7 +380,7 @@
 					position: relative;
 					width: 100%;
 					> * {
-						justify-content:end;
+						justify-content:flex-end;
 					}
 				}
 				.cm-header {
@@ -427,7 +427,7 @@
 				}
 			}
 		}
-			
+
 	}
 
 	&.notice--center,
@@ -507,7 +507,7 @@
 						// float:unset;
 						// height: 40px;
 						// line-height: 40px;
-					// }	
+					// }
 				}
 			}
 		}
@@ -587,11 +587,11 @@
 // Ver 2.0.2 - gf20210922 END.
 	}
 }
-// Ver 2.0.1 -gf20210921 END. 
-// ************************** 
+// Ver 2.0.1 -gf20210921 END.
+// **************************
 
-// Ver 3.0.2 - gf20220517 
-// Anpassungen spez. für Safari 
+// Ver 3.0.2 - gf20220517
+// Anpassungen spez. für Safari
 .safari {
   .klaro.we_cookie_consent .cookie-modal .cm-modal.cm-klaro {
     bottom: 0;


### PR DESCRIPTION
I added `!default` to all the scss variables, so it is easy to override them from an outside file.

This makes it easier to use the existing file in our own sass build, where we can just adapt the colors as needed.