### PR TITLE
Bugfix: PHP Warning: Undefined array key "purposeOrder" when no services defined.

### DIFF
--- a/Classes/Controller/ConsentController.php
+++ b/Classes/Controller/ConsentController.php
@@ -167,6 +167,7 @@ class ConsentController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControll
             'mustConsent' => $this->settings['klaro']['mustConsent'] === '1',
             'poweredBy' => $poweredByPage,
             'privacyPolicy' => $privacyPage,
+            'purposeOrder' => [],
             'storageMethod' => $this->settings['klaro']['storageMethod'],
             'storageName' => $this->settings['klaro']['storageName'],
             'stylePrefix' => $this->settings['klaro']['stylePrefix'],


### PR DESCRIPTION
An error line is filing my log file:  

Core: Error handler (FE): PHP Warning: Undefined array key "purposeOrder" in /app/vendor/websedit/we-cookie-consent/Classes/Controller/ConsentController.php line 247

This PR fixes it.